### PR TITLE
add _GNU_SOURCE for asprintf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CFLAGS	:=	-g -Wall -O2 -mword-relocations -save-temps \
 			-fomit-frame-pointer -ffast-math \
 			$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS
+CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -D_GNU_SOURCE
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 


### PR DESCRIPTION
Tested with current devkitpro. Without this definition it won't compile on `asprintf` usage in `savedatacheck.cpp`.